### PR TITLE
Fix blank page from 'register' link in email

### DIFF
--- a/account.php
+++ b/account.php
@@ -29,10 +29,12 @@ if (!$cfg || !$cfg->isClientRegistrationEnabled()) {
 elseif ($thisclient) {
     // Guest registering for an account
     if ($thisclient->isGuest()) {
-        foreach ($thisclient->getForms() as $f)
-            if ($f->get('type') == 'U')
+        foreach ($thisclient->getForms() as $f) {
+            if ($f->get('type') == 'U') {
                 $user_form = $f;
-        $user_form->getField('email')->configure('disabled', true);
+                $user_form->getField('email')->configure('disabled', true);
+            }
+        }    
     }
     // Existing client (with an account) updating profile
     else {


### PR DESCRIPTION
We have existing clients who do not have an account (yet) on osTicket.  We create a ticket for them from the admin interface (creating a new guest user account) and this results in an email being sent to them with details of a job carried out.  This user can then click on the link in the notification email and view the ticket as guest - and hopefully opt to register an account.

The problem seems to be this - the user clicks on the ticket number in their notification email which lets them view the ticket as a guest - there is then a link to 'register for an account' linked to http://www.example.com/account.php?do=create - but clicking this link results in a blank page.  The PHP error is:

PHP Fatal error:  Call to a member function getField() on a non-object in /home/osticket/public_html/account.php on line 35, referer: http://www.example.com/tickets.php?id=105

This seems to be related to a bug in account.php around line 34.

    // Guest registering for an account                                                                                                      
    if ($thisclient->isGuest()) {
        foreach ($thisclient->getForms() as $f)
            if ($f->get('type') == 'U')
                $user_form = $f;
        $user_form->getField('email')->configure('disabled', true);
    }

If    $f->get('type')   is not equal to 'U' then $user_form does not get set - and therefore:
    $user_form->getField('email')->configure('disabled', true);

results in the 'call member function on a non-object error'.

I think the block should be:

    // Guest registering for an account                                                                                                      
    if ($thisclient->isGuest()) {
        foreach ($thisclient->getForms() as $f)
            if ($f->get('type') == 'U') {
                $user_form = $f;
                $user_form->getField('email')->configure('disabled', true);
            }
    }

Further - to be implicit the foreach statement should have curly braces.

    // Guest registering for an account                                                                                                      
    if ($thisclient->isGuest()) {
        foreach ($thisclient->getForms() as $f) {
            if ($f->get('type') == 'U') {
                $user_form = $f;
                $user_form->getField('email')->configure('disabled', true);
            }
        }
    }